### PR TITLE
Improves output for JUnit tests, including grouping results

### DIFF
--- a/src/main/java/com/spertus/jacquard/common/Result.java
+++ b/src/main/java/com/spertus/jacquard/common/Result.java
@@ -42,7 +42,7 @@ public class Result {
     }
 
     @VisibleForTesting
-    /* package private */ static String trimMessage(final String message, int maxLength, String overflowIndicator) {
+    static String trimMessage(final String message, int maxLength, String overflowIndicator) {
         if (message.length() > maxLength) {
             return message.substring(0, maxLength - overflowIndicator.length())
                     + overflowIndicator;

--- a/src/main/java/com/spertus/jacquard/common/Result.java
+++ b/src/main/java/com/spertus/jacquard/common/Result.java
@@ -1,5 +1,7 @@
 package com.spertus.jacquard.common;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -8,6 +10,9 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class Result {
+    private static final int MAX_MESSAGE_LENGTH = 8192;
+    private static final String MESSAGE_OVERFLOW_INDICATOR = "...";
+
     private final String name;
     private final double score;
     private final double maxScore;
@@ -32,8 +37,18 @@ public class Result {
         this.name = name;
         this.score = score;
         this.maxScore = maxScore;
-        this.message = message;
+        this.message = trimMessage(message, MAX_MESSAGE_LENGTH, MESSAGE_OVERFLOW_INDICATOR);
         this.visibility = visibility;
+    }
+
+    @VisibleForTesting
+    /* package private */ static String trimMessage(final String message, int maxLength, String overflowIndicator) {
+        if (message.length() > maxLength) {
+            return message.substring(0, maxLength - overflowIndicator.length())
+                    + overflowIndicator;
+        } else {
+            return message;
+        }
     }
 
     /**

--- a/src/main/java/com/spertus/jacquard/common/Result.java
+++ b/src/main/java/com/spertus/jacquard/common/Result.java
@@ -161,7 +161,8 @@ public class Result {
     }
 
     /**
-     * Makes a result with the provided score.
+     * Makes a result with the provided score and message with the visibility level specified in
+     * {@link Autograder#visibility}.
      *
      * @param name        the name
      * @param actualScore the number of points earned
@@ -175,6 +176,25 @@ public class Result {
             final double maxScore,
             final String message) {
         return new Result(name, actualScore, maxScore, message);
+    }
+
+    /**
+     * Makes a result with the provided characteristics.
+     *
+     * @param name        the name
+     * @param actualScore the number of points earned
+     * @param maxScore    the number of points possible
+     * @param message     any message
+     * @param visibility  the visibility
+     * @return a result
+     */
+    public static Result makeResult(
+            final String name,
+            final double actualScore,
+            final double maxScore,
+            final String message,
+            final Visibility visibility) {
+        return new Result(name, actualScore, maxScore, message, visibility);
     }
 
     /**

--- a/src/main/java/com/spertus/jacquard/junittester/GradedTest.java
+++ b/src/main/java/com/spertus/jacquard/junittester/GradedTest.java
@@ -27,6 +27,11 @@ public @interface GradedTest {
     String name() default "";
 
     /**
+     * A description of the defect detected by this test.
+     */
+    String description() default "";
+
+    /**
      * The number of points the test is worth.
      *
      * @return the number of points the test is worth

--- a/src/main/java/com/spertus/jacquard/junittester/GradedTest.java
+++ b/src/main/java/com/spertus/jacquard/junittester/GradedTest.java
@@ -28,6 +28,8 @@ public @interface GradedTest {
 
     /**
      * A description of the defect detected by this test.
+     *
+     * @return the description
      */
     String description() default "";
 

--- a/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
+++ b/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
@@ -66,12 +66,16 @@ public class JUnitTester extends Tester {
         }
         launcher.execute(builder.build());
         System.setOut(originalOut);
-        return listener.results;
+        return processResults(listener.results);
     }
 
+    // Note that the merged result has the default visibility set when the autograder was constructed.
     @VisibleForTesting
     static Result mergeResults(List<Result> results) {
         Preconditions.checkArgument(!results.isEmpty());
+        if (results.size() == 1) {
+            return results.get(0);
+        }
         String name = results.get(0).getName();
         Preconditions.checkArgument(
                 results.stream().allMatch((r) -> r.getName().equals(name)));
@@ -89,7 +93,9 @@ public class JUnitTester extends Tester {
         return Result.makeResult(name, score, maxScore, message);
     }
 
-    private static List<Result> processResults(ArrayList<Result> results) {
+    // Merge all the results having the same name. The merged result has the
+    // default visibility level specified when creating the autograder.
+    private static List<Result> processResults(List<Result> results) {
         return results.stream()
                 .collect(Collectors.groupingBy(Result::getName))
                 .values()

--- a/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
+++ b/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
@@ -121,20 +121,20 @@ public class JUnitTester extends Tester {
             System.setOut(ps);
         }
 
-        private String makeMessage(final String description, final TestExecutionResult teResult) {
+        private String makeMessage(final GradedTest gt, final TestExecutionResult teResult) {
             final List<String> items = new ArrayList<>();
 
             // First, use description, if present.
-            if (!description.isEmpty()) {
-                items.add(description);
+            if (!gt.description().isEmpty()) {
+                items.add(gt.description());
             }
 
             // Second, use throwable, if present.
             teResult.getThrowable().ifPresent(value -> items.add(value.toString()));
 
-            // Third, include output, if present.
-            final String output = baos.toString();
-            if (!output.isEmpty()) {
+            // Third, include output, if present and supposed to be shown.
+            final String output = baos.toString().trim();
+            if (gt.includeOutput() && !output.isEmpty()) {
                 items.add("OUTPUT");
                 items.add("======");
                 items.add(output);
@@ -155,9 +155,9 @@ public class JUnitTester extends Tester {
                         try {
                             final Result result = switch (testExecutionResult.getStatus()) {
                                 case SUCCESSFUL ->
-                                        Result.makeSuccess(name, gt.points(), baos.toString());
+                                        Result.makeSuccess(name, gt.points(), makeMessage(gt, testExecutionResult));
                                 case FAILED, ABORTED ->
-                                        Result.makeFailure(name, gt.points(), makeMessage(gt.description(), testExecutionResult));
+                                        Result.makeFailure(name, gt.points(), makeMessage(gt, testExecutionResult));
                             };
                             results.add(result.changeVisibility(gt.visibility()));
                             ps.close();

--- a/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
+++ b/src/main/java/com/spertus/jacquard/junittester/JUnitTester.java
@@ -82,16 +82,25 @@ public class JUnitTester extends Tester {
             System.setOut(ps);
         }
 
-        private String makeOutput(final TestExecutionResult teResult) {
-            final Optional<Throwable> throwable = teResult.getThrowable();
-            final String s = baos.toString();
-            if (throwable.isEmpty()) {
-                return s;
-            } else if (s.isEmpty()) {
-                return throwable.get().toString();
-            } else {
-                return s + "\n" + throwable.get();
+        private String makeMessage(final String description, final TestExecutionResult teResult) {
+            final List<String> items = new ArrayList<>();
+
+            // First, use description, if present.
+            if (!description.isEmpty()) {
+                items.add(description);
             }
+
+            // Second, use throwable, if present.
+            teResult.getThrowable().ifPresent(value -> items.add(value.toString()));
+
+            // Third, include output, if present.
+            final String output = baos.toString();
+            if (!output.isEmpty()) {
+                items.add("OUTPUT");
+                items.add("======");
+                items.add(output);
+            }
+            return String.join("\n", items);
         }
 
         @Override
@@ -109,7 +118,7 @@ public class JUnitTester extends Tester {
                                 case SUCCESSFUL ->
                                         Result.makeSuccess(name, gt.points(), baos.toString());
                                 case FAILED, ABORTED ->
-                                        Result.makeFailure(name, gt.points(), makeOutput(testExecutionResult));
+                                        Result.makeFailure(name, gt.points(), makeMessage(gt.description(), testExecutionResult));
                             };
                             results.add(result.changeVisibility(gt.visibility()));
                             ps.close();

--- a/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
+++ b/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
@@ -61,7 +61,11 @@ public class JUnitTesterTest {
     public void testPackageIncludingSubpackages() {
         JUnitTester tester = new JUnitTester("com.spertus.jacquard.junittester", true);
         List<Result> results = tester.run();
-        assertEquals(9, results.size());
+        // There should be:
+        // 2 results from SampleTest
+        // 1 result from GroupTest
+        // 5 results from VisibilityTest
+        assertEquals(8, results.size());
     }
 
     @Test

--- a/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
+++ b/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
@@ -4,6 +4,7 @@ import com.spertus.jacquard.common.*;
 import com.spertus.jacquard.junittester.SampleTest;
 import com.spertus.jacquard.junittester.JUnitTester;
 import com.spertus.jacquard.junittester.group.GroupTest;
+import com.spertus.jacquard.junittester.output.OutputTest;
 import com.spertus.jacquard.junittester.visibility.VisibilityLevelsTest;
 import org.junit.jupiter.api.*;
 
@@ -62,10 +63,11 @@ public class JUnitTesterTest {
         JUnitTester tester = new JUnitTester("com.spertus.jacquard.junittester", true);
         List<Result> results = tester.run();
         // There should be:
-        // 2 results from SampleTest
         // 1 result from GroupTest
+        // 2 from OutputTest
+        // 2 results from SampleTest
         // 5 results from VisibilityTest
-        assertEquals(8, results.size());
+        assertEquals(10, results.size());
     }
 
     @Test
@@ -92,5 +94,17 @@ public class JUnitTesterTest {
         JUnitTester tester = new JUnitTester(GroupTest.class);
         List<Result> results = tester.run();
         assertEquals(1, results.size());
+    }
+
+    @Test
+    public void testOutput() {
+        JUnitTester tester = new JUnitTester(OutputTest.class);
+        List<Result> results = tester.run();
+        assertEquals(2, results.size());
+        // The test with name1, description1 should have no output included.
+        Result result1 = results.get(0).getName().equals("name1") ? results.get(0) : results.get(1);
+        Result result2 = result1.equals(results.get(0)) ? results.get(1) : results.get(0);
+        assertEquals("description1", result1.getMessage());
+        assertEquals("description2\nOUTPUT\n======\noutput2", result2.getMessage());
     }
 }

--- a/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
+++ b/src/test/java/com/spertus/jacquard/JUnitTesterTest.java
@@ -3,6 +3,7 @@ package com.spertus.jacquard;
 import com.spertus.jacquard.common.*;
 import com.spertus.jacquard.junittester.SampleTest;
 import com.spertus.jacquard.junittester.JUnitTester;
+import com.spertus.jacquard.junittester.group.GroupTest;
 import com.spertus.jacquard.junittester.visibility.VisibilityLevelsTest;
 import org.junit.jupiter.api.*;
 
@@ -60,7 +61,7 @@ public class JUnitTesterTest {
     public void testPackageIncludingSubpackages() {
         JUnitTester tester = new JUnitTester("com.spertus.jacquard.junittester", true);
         List<Result> results = tester.run();
-        assertEquals(7, results.size());
+        assertEquals(9, results.size());
     }
 
     @Test
@@ -80,5 +81,12 @@ public class JUnitTesterTest {
             assertEquals(expectedVisibility, result.getVisibility(),
                     "Visibility incorrect for " + result.getName());
         }
+    }
+
+    @Test
+    public void testGrouping() {
+        JUnitTester tester = new JUnitTester(GroupTest.class);
+        List<Result> results = tester.run();
+        assertEquals(1, results.size());
     }
 }

--- a/src/test/java/com/spertus/jacquard/common/ResultTest.java
+++ b/src/test/java/com/spertus/jacquard/common/ResultTest.java
@@ -1,6 +1,5 @@
-package com.spertus.jacquard;
+package com.spertus.jacquard.common;
 
-import com.spertus.jacquard.common.*;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
@@ -66,5 +65,19 @@ public class ResultTest {
     @Test
     public void testReorderIncreasingMaxScore() {
         assertEquals(List.of(rMixed, rBigSuccess, rHugeFailure), Result.reorderResults(results, Result.Order.INCREASING_MAX_SCORE));
+    }
+
+    @Test
+    public void testTrimMessage() {
+        String message = "Hello, world!";
+        assertEquals(message, Result.trimMessage(message, message.length(), "..."));
+        assertEquals(
+                "Hello, wo...",
+                Result.trimMessage(message, message.length() - 1, "...")
+        );
+        assertEquals(
+                "Hello!",
+                Result.trimMessage(message, 6, "!")
+        );
     }
 }

--- a/src/test/java/com/spertus/jacquard/junittester/MergeResultsTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/MergeResultsTest.java
@@ -70,16 +70,17 @@ public class MergeResultsTest {
         }
     }
 
+    // single results don't get merged
     @Test
     public void testMerge1() {
         // Success
-        assertMatching(NAME, 1.0, 1.0, "", List.of(result1));
+        assertMatching(NAME, 1.0, 1.0, "message1", List.of(result1));
 
         // Failure
-        assertMatching(NAME, 0.0, 2.0, "-2.0: message2", List.of(result2));
+        assertMatching(NAME, 0.0, 2.0, "message2", List.of(result2));
 
         // Partial success
-        assertMatching(NAME, 3.5, 4.0, "-0.5: message3", List.of(result3));
+        assertMatching(NAME, 3.5, 4.0, "message3", List.of(result3));
     }
 
     @Test

--- a/src/test/java/com/spertus/jacquard/junittester/MergeResultsTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/MergeResultsTest.java
@@ -1,0 +1,112 @@
+package com.spertus.jacquard.junittester;
+
+import com.google.common.collect.Sets;
+import com.spertus.jacquard.JUnitTesterTest;
+import com.spertus.jacquard.common.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MergeResultsTest {
+    public static final String NAME = "name";
+    private static Result result1;
+    private static Result result2;
+    private static Result result3;
+
+    @BeforeEach
+    public void setup() {
+        Autograder.initForTest();
+        result1 = Result.makeSuccess(NAME, 1.0, "message1");
+        result2 = Result.makeFailure(NAME, 2.0, "message2");
+        result3 = Result.makeResult(NAME, 3.5, 4.0, "message3");
+    }
+
+    @Test
+    public void testMerge0() {
+        assertThrows(IllegalArgumentException.class, () -> JUnitTester.mergeResults(List.of()));
+    }
+
+    @Test
+    public void testMergeDifferentNames() {
+        List<Result> mismatchedResults = List.of(
+                result1,
+                Result.makeFailure("different name", 5.0, "ignored message")
+        );
+        assertThrows(IllegalArgumentException.class, () -> JUnitTester.mergeResults(mismatchedResults));
+    }
+
+    // Checks if strings have same lines, possibly in different order.
+    private void assertSameLines(String s1, String s2) {
+        Set<String> lines1 = Sets.newHashSet(s1.split("\n"));
+        Set<String> lines2 = Sets.newHashSet(s2.split("\n"));
+        if (lines1.equals(lines2)) {
+            return;
+        }
+        // This provides better messages than just failing.
+        for (String s : lines1) {
+            assertTrue(lines2.contains(s));
+        }
+        for (String s : lines2) {
+            assertTrue(lines1.contains(s));
+        }
+    }
+
+    // Checks if all resultLists produce results that match the arguments.
+    private void assertMatching(
+            String name,
+            double score,
+            double maxScore,
+            String message,
+            List<Result>... resultLists
+    ) {
+        for (List<Result> resultList : resultLists) {
+            Result result = JUnitTester.mergeResults(resultList);
+            assertEquals(name, result.getName());
+            assertEquals(score, result.getScore());
+            assertEquals(maxScore, result.getMaxScore());
+            assertSameLines(message, result.getMessage());
+        }
+    }
+
+    @Test
+    public void testMerge1() {
+        // Success
+        assertMatching(NAME, 1.0, 1.0, "", List.of(result1));
+
+        // Failure
+        assertMatching(NAME, 0.0, 2.0, "-2.0: message2", List.of(result2));
+
+        // Partial success
+        assertMatching(NAME, 3.5, 4.0, "-0.5: message3", List.of(result3));
+    }
+
+    @Test
+    public void testMerge2() {
+        // One success, one failure
+        assertMatching(NAME, 1.0, 3.0, "-2.0: message2",
+                List.of(result1, result2),
+                List.of(result2, result1));
+
+        // One success, one partial
+        assertMatching(NAME, 4.5, 5.0, "-0.5: message3",
+                List.of(result1, result3),
+                List.of(result3, result1));
+
+        // One partial, one failure
+        assertMatching(NAME, 3.5, 6.0, "-2.0: message2\n-0.5: message3",
+                List.of(result2, result3), List.of(result3, result2));
+    }
+
+    @Test
+    public void testMerge3() {
+        assertMatching(NAME, 4.5, 7.0, "-2.0: message2\n-0.5: message3",
+                List.of(result1, result2, result3),
+                List.of(result1, result3, result2),
+                List.of(result2, result1, result3),
+                List.of(result2, result3, result1),
+                List.of(result3, result1, result2),
+                List.of(result3, result2, result1));
+    }
+}

--- a/src/test/java/com/spertus/jacquard/junittester/group/GroupTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/group/GroupTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+// These 2 tests should get merged together.
 @Tag("IndirectTest")
 public class GroupTest {
     @Test

--- a/src/test/java/com/spertus/jacquard/junittester/group/GroupTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/group/GroupTest.java
@@ -1,0 +1,25 @@
+package com.spertus.jacquard.junittester.group;
+
+import com.spertus.jacquard.junittester.GradedTest;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Tag("IndirectTest")
+public class GroupTest {
+    @Test
+    @GradedTest(name = "Bus constructor",
+            description = "Verifies exception is thrown for null argument",
+            points = 2.0)
+    public void testBusConstructor1() {
+        fail();
+    }
+
+    @Test
+    @GradedTest(name = "Bus constructor",
+            description = "Verifies exception is thrown for bad route",
+            points = 3.0)
+    public void testBusConstructor2() {
+        // pass
+    }
+}

--- a/src/test/java/com/spertus/jacquard/junittester/output/OutputTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/output/OutputTest.java
@@ -1,0 +1,21 @@
+package com.spertus.jacquard.junittester.output;
+
+import com.spertus.jacquard.junittester.GradedTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("IndirectTest")
+public class OutputTest {
+    @Test
+    @GradedTest(name = "test1", description = "description1", includeOutput = false)
+    public void testWithoutOutput() {
+        System.out.println("output1");
+        // pass
+    }
+
+    @Test
+    @GradedTest(name = "test2", description = "description2", includeOutput = true)
+    public void testWithOutput() {
+        System.out.println("output2");
+    }
+}

--- a/src/test/java/com/spertus/jacquard/junittester/visibility/VisibilityLevelsTest.java
+++ b/src/test/java/com/spertus/jacquard/junittester/visibility/VisibilityLevelsTest.java
@@ -2,10 +2,12 @@ package com.spertus.jacquard.junittester.visibility;
 
 import com.spertus.jacquard.common.Visibility;
 import com.spertus.jacquard.junittester.GradedTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Tag("IndirectTest")
 public class VisibilityLevelsTest {
     @Test
     @GradedTest(points = 2.0)


### PR DESCRIPTION
* Adds `description` field to `@GradedResult`
* Includes `description` along with stdout in `TestResult.message` (the `output` field on Gradescope)
* Adds limit to message length
* Groups together tests with the same name, with messages included only for failing tests

This change is visible to existing users because it changes the output formatting.